### PR TITLE
update_timeout_doc timeout=0 or timeout=None equiv to poll_forever=True

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://travis-ci.com/ddmee/polling2.svg?branch=master)](https://travis-ci.org/ddmee/polling2)
 [![PyPI](https://img.shields.io/pypi/dm/polling2.svg)]()
 [![PyPI](https://img.shields.io/pypi/v/polling2.svg)]()
-[![HitCount](http://hits.dwyl.io/ddmee/polling2.svg)](http://hits.dwyl.io/ddmee/polling2)
 
 # polling2
 

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -6,7 +6,7 @@ Contributions are very welcome. This library is under active development.
 It's important that any changes work on both python 2 and python 3.
 
 Development Setup
-----------
+-----------------
 
 You can get your development environment running cloning the repository. Please test your changes. Do note any PRs you open, Travis will run and report the test results. So perhaps you can just rely on opening a PR::
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -176,6 +176,7 @@ Poll a target forever
 If you do not want to set a timeout on the polled target, you can set the poll_forever parameter to true. This will poll the target forever *until* the target returns the value you expect.
 
 ::
+
     from polling2 import poll
     # Target function returns False. The default check_success looks for a truthy value to be returned.
     # This will call the target function forever, with a one second wait between polls.
@@ -184,6 +185,7 @@ If you do not want to set a timeout on the polled target, you can set the poll_f
 Note, that setting the timeout parameter to None or 0 has the equivalent effect as setting the poll_forever parameter to true. E.g.:
 
 ::
+
     from polling2 import poll
     # Setting timeout to zero is equivalent to setting poll_forever=True.
     # This call will also poll the target forever.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -168,3 +168,23 @@ code snippet, the ValueError raised by the function `raises_error()` will be sen
         )
     except RuntimeError as _e:
         print "Un-ignored %r" % _e"
+
+
+Poll a target forever
+---------------------
+
+If you do not want to set a timeout on the polled target, you can set the poll_forever parameter to true. This will poll the target forever *until* the target returns the value you expect.
+
+::
+    from polling2 import poll
+    # Target function returns False. The default check_success looks for a truthy value to be returned.
+    # This will call the target function forever, with a one second wait between polls.
+    poll(target=lambda: False, step=1, poll_forever=True)
+
+Note, that setting the timeout parameter to None or 0 has the equivalent effect as setting the poll_forever parameter to true. E.g.:
+
+::
+    from polling2 import poll
+    # Setting timeout to zero is equivalent to setting poll_forever=True.
+    # This call will also poll the target forever.
+    poll(target=lambda: False, step=1, timeout=0)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,9 +14,6 @@ Release v\ |version|.
 .. image:: https://img.shields.io/pypi/dm/polling2.svg
     :target: https://pypi.org/project/polling2
 
-.. image:: http://hits.dwyl.io/ddmee/polling2.svg
-    :target: https://pypi.org/project/polling2
-
 .. image:: https://img.shields.io/pypi/pyversions/polling2.svg
     :target: https://pypi.org/project/polling2
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,6 +1,11 @@
 Release notes
 =============
 
+0.4.7
+-----
+
+- No API changes. Updated documentation to state that timeout=0 or timeout=None is equivalent to setting poll_forever=True.
+
 0.4.6
 -----
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ packaging==20.4
 Pygments==2.7.4
 pyparsing==2.4.7
 pytz==2020.1
-requests==2.24.0
+requests==2.25.1
 six==1.15.0
 snowballstemmer==2.0.0
 Sphinx==3.2.1

--- a/polling2.py
+++ b/polling2.py
@@ -4,7 +4,7 @@ Never write another polling function again.
 
 """
 
-__version__ = '0.4.6'
+__version__ = '0.4.7'
 
 import logging
 import time
@@ -104,10 +104,11 @@ def poll(target, step, args=(), kwargs=None, timeout=None, max_tries=None, check
     :param kwargs: Keyword arguments to be passed to the target function
 
     :param timeout: The target function will be called until the time elapsed is greater than the maximum timeout
-        (in seconds). NOTE that the actual execution time of the function *can* exceed the time specified in the timeout.
+        (in seconds). NOTE timeout == 0 or timeout == None is equivalent to setting poll_forever=True.
+        NOTE that the actual execution time of the function *can* exceed the time specified in the timeout.
         For instance, if the target function takes 10 seconds to execute and the timeout is 21 seconds, the polling
         function will take a total of 30 seconds (two iterations of the target --20s which is less than the timeout--21s,
-        and a final iteration)
+        and a final iteration).
 
     :param max_tries: Maximum number of times the target function will be called before failing
 


### PR DESCRIPTION
Make the documentation clear, per issue discussion on github.
Bump verison number to 0.4.7
Also remove broken link on readme.md front-page.