### PR TITLE
Update poll step_function param description

### DIFF
--- a/polling2.py
+++ b/polling2.py
@@ -143,7 +143,7 @@ def poll(
 
         >>> def my_step_function(step):
         >>>     step += 10
-        >>>     return max(step, 100)
+        >>>     return min(step, 100)
 
     :type ignore_exceptions: tuple
     :param ignore_exceptions: You can specify a tuple of exceptions that should be caught and ignored on every


### PR DESCRIPTION
Changes code example to accurately demonstrate the text of the param description. The description is:

> As an example, you can increase the wait time between calling the target function by 10 seconds every iteration until the step is 100 seconds--at which point it should remain constant at 100 seconds

If `step` reaches `100`, then `step += 10` becomes `110`, and `max(110, 100) == 110`, so `110` is returned as the next step. 

Changing `max` to `min` will make the code example accurate. 

PS: Thanks for the great library, it's been super useful!